### PR TITLE
object.__new__ only takes a single parameter

### DIFF
--- a/normalize/property/meta.py
+++ b/normalize/property/meta.py
@@ -59,7 +59,7 @@ def has(selfie, self, args, kwargs):
             )
         )
 
-    return super(selfie, self).__new__(property_type, *args, **kwargs)
+    return super(selfie, self).__new__(property_type)
 
 
 class MetaProperty(type):


### PR DESCRIPTION
`object.__new__()` only takes a class parameter - anything else passed just gets tossed in the bin. This doesn't create any practical problems, but [the BDFL has deprecated it](https://mail.python.org/pipermail/python-dev/2008-February/076854.html).

I noticed this in the main app's Django test suite:

```
/home/ashah/projects/HearsayLabs/external/normalize/property/meta.py:62: DeprecationWarning: object.__new__() takes no parameters
  return super(selfie, self).__new__(property_type, *args, **kwargs)
```

/review @samv 
