### PR TITLE
JSON marshal out should always call 'json_data()'

### DIFF
--- a/normalize/record/json.py
+++ b/normalize/record/json.py
@@ -138,7 +138,7 @@ def to_json(record, extraneous=True):
                 else:
                     if hasattr(prop, "to_json"):
                         val = prop.to_json(val)
-                    rv_dict[json_name] = to_json(val, extraneous)
+                    rv_dict[json_name] = _json_data(val, extraneous)
 
         return rv_dict
 

--- a/tests/test_marshal.py
+++ b/tests/test_marshal.py
@@ -316,3 +316,26 @@ class TestRecordMarshaling(unittest2.TestCase):
         self.assertNotIn("origin", sanitized)
 
         self.assertJsonDataEqual(rjcr.json_data(extraneous=True), input_json)
+
+        class NestedJsonRecord(JsonRecord):
+            cheese = Property(isa=JsonCheeseRecord)
+            cheese_list = ListProperty(of=JsonCheeseRecord)
+
+        nested_input = dict(
+            cheese=input_json,
+            cheese_list=[
+                {"variety": "Cream Havarti",
+                 "type": "semi-soft",
+                 "color": "pale yellow"},
+                {"variety": "Adelost",
+                 "type": "semi-soft",
+                 "color": "blue"},
+            ],
+        )
+
+        nested_record = NestedJsonRecord(nested_input)
+
+        self.assertJsonDataEqual(
+            nested_record.json_data(extraneous=True),
+            nested_input,
+        )


### PR DESCRIPTION
During a recent refactor this function was changed to recurse directly
instead of through the helper function.  This broke the functionality of
.json_data(extraneous=True) being a safe round-trip in a well-oiled
JsonRecord class.  Fix it.

/cc @rbm @adepue 
