### PR TITLE
Add test for potentially faulty LazyProperty behavior

### DIFF
--- a/tests/test_property.py
+++ b/tests/test_property.py
@@ -152,6 +152,7 @@ class TestProperties(unittest2.TestCase):
         # lazy properties may be assigned
         tdr.fired = None
         self.assertEqual(tdr.fired, None)
+        self.assertEqual(TrapDoorRecord.fired.__get__(tdr), None)
 
         # delete and start again!
         tdr.chamber = "bullet"


### PR DESCRIPTION
`LazyProperty.__get__` gets the default value first before checking to see if the value already exists. I believe this to be a bug.