### PR TITLE
Make empty attributes return magic falsy objects instead of instances

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 Normalize changelog and errata
 ==============================
 
+0.8.0 6th March 2015
+--------------------
+* ``bool(record)`` was reverted to pre-0.7.x behavior: always True,
+  unless a Collection in which case Falsy depending on the number of
+  members in the collection.
+
+* Empty psuedo-attributes now return ``normalize.empty.EmptyVal``
+  objects, which are always ``False`` and perform a limited amount of
+  sanity checking/type inference, so that misspellings of sub-properties
+  can sometimes be caught.
+
 0.7.4 5th March 2015
 --------------------
 * A regression which introduced subtle bugs in 0.7.0, which became more

--- a/normalize/coll.py
+++ b/normalize/coll.py
@@ -162,9 +162,6 @@ class Collection(Record):
             coll='Collection',
         )
 
-    def __nonzero__(self):
-        return super(Collection, self).__nonzero__() or bool(len(self))
-
 
 class KeyedCollection(Collection):
     def __getitem__(self, item):

--- a/normalize/empty.py
+++ b/normalize/empty.py
@@ -1,0 +1,124 @@
+
+import normalize
+
+
+EMPTY_VALS = dict()
+        
+
+def placeholder(type_):
+    typetuple = type_ if isinstance(type_, tuple) else (type_,) 
+    if any in typetuple:
+        typetuple = any
+    if typetuple not in EMPTY_VALS:
+        EMPTY_VALS[typetuple] = EmptyVal(typetuple)
+    return EMPTY_VALS[typetuple]
+
+
+def itertypes(iterable):
+    seen = set()
+    for entry in iterable:
+        if isinstance(entry, tuple):
+            for type_ in entry:
+                if type_ not in seen:
+                    seen.add(type_)
+                    yield type_
+        else:
+            if entry not in seen:
+                seen.add(entry)
+                yield entry
+
+
+class EmptyVal(object):
+    def __init__(self, typetuple):
+        self._typetuple = typetuple
+        self._attrs = {}
+        self._member_type = None
+
+    def __getattr__(self, attr_name):
+        if self._typetuple is any:
+            return self
+        if attr_name not in self._attrs:
+            attrs_found = []
+            all_record = None
+            for type_ in self._typetuple:
+                is_record = issubclass(type_, normalize.record.Record)
+                if is_record:
+                    if all_record is None:
+                        all_record = True
+                else:
+                    all_record = False
+                prop = getattr(type_, attr_name, None)
+                if prop is None:
+                    if getattr(type_, "__getattr__", None):
+                        attrs_found.append(None)
+                else:
+                    attrs_found.append(prop)
+        
+            if not attrs_found and all_record:
+                raise self._exc(
+                    "NoSuchAttribute",
+                    attribute=attr_name,
+                )
+            elif attrs_found:
+                self._attrs[attr_name] = placeholder(
+                    tuple(itertypes(getattr(attr, "valuetype", any) for
+                                    attr in attrs_found))
+                )
+            else:
+                self._attrs[attr_name] = placeholder(any)
+        return self._attrs[attr_name]
+
+    def __setattr__(self, item, value):
+        if item in ("_typetuple", "_attrs", "_member_type"):
+            self.__dict__[item] = value
+        else:
+            raise self._exc("BadAssignment")
+
+    def __setitem__(self, item):
+        raise self._exc("BadAssignment")
+
+    def __call__(self, *args, **kwargs):
+        if self._typetuple is any:
+            return self
+        for type_ in self._typetuple:
+            if hasattr(type_, "__call__"):
+                return placeholder(any)
+            raise self._exc('CannotInvoke')
+
+    def __getitem__(self, item):
+        if self._typetuple is any:
+            return self
+        if isinstance(item, slice):
+            return self
+        elif self._member_type is None:
+            all_record = None
+            coll_types = []
+            for type_ in self._typetuple:
+                is_record = issubclass(type_, normalize.record.Record)
+                if is_record:
+                    if all_record is None:
+                        all_record = True
+                    is_coll = issubclass(type_, normalize.coll.Collection)
+                    if is_coll:
+                        coll_types.append(type_.itemtype)
+                else:
+                    all_record = False
+
+            if all_record and not coll_types:
+                raise self._exc("NotSubscriptable")
+            elif coll_types:
+                self._member_type = placeholder(tuple(itertypes(coll_types)))
+            else:
+                self._member_type = placeholder(any)
+        return self._member_type
+
+    def __nonzero__(self):
+        return False
+
+    def _exc(self, which, **kwargs):
+        return getattr(normalize.exc, which)(
+            typenames=",".join(
+                str(t.__name__) for t in self._typetuple
+                    if isinstance(t, type)
+            ),
+            **kwargs)

--- a/normalize/empty.py
+++ b/normalize/empty.py
@@ -54,8 +54,12 @@ class EmptyVal(object):
                 )
             elif attrs_found:
                 self._attrs[attr_name] = placeholder(
-                    tuple(itertypes(getattr(attr, "valuetype", any) for
-                                    attr in attrs_found))
+                    tuple(
+                        itertypes(
+                            getattr(attr, "valuetype", False) or any for
+                            attr in attrs_found
+                        )
+                    )
                 )
         return self._attrs[attr_name]
 

--- a/normalize/empty.py
+++ b/normalize/empty.py
@@ -6,6 +6,7 @@ EMPTY_VALS = dict()
         
 
 def placeholder(type_):
+    """Returns the EmptyVal instance for the given type"""
     typetuple = type_ if isinstance(type_, tuple) else (type_,) 
     if any in typetuple:
         typetuple = any
@@ -15,6 +16,8 @@ def placeholder(type_):
 
 
 def itertypes(iterable):
+    """Iterates over an iterable containing either type objects or tuples of
+    type objects and yields once for every type object found."""
     seen = set()
     for entry in iterable:
         if isinstance(entry, tuple):
@@ -29,6 +32,24 @@ def itertypes(iterable):
 
 
 class EmptyVal(object):
+    """Empty Value placeholder for a given tuple of types.  This object's
+    ``__nonzero__`` always returns ``False``, and it knows how to infer types
+    as its attributes are accessed and/or lists are de-referenced: so long as
+    there are type hints in the places normalize puts them.
+
+    Each set of types gets a single, persistent ``EmptyVal`` object.  The
+    special ``EmptyVal(any)`` is used when types cannot be inferred, and never
+    raises any errors: it just returns itself when invoked etc.
+
+    If types can be inferred, then exceptions are raised when invalid
+    attributes are accessed, or a type which does not implement ``__getitem__``
+    is dereferenced, or a type which does not supply ``__call__`` is invoked.
+
+    This function will raise exceptions badly when you try to access variables
+    which are only available in a subclass of the declared class on the type
+    hint, or when a property attribute is set by a method (eg, ``__init__``)
+    rather than declared on the class.
+    """
     def __init__(self, typetuple):
         self._typetuple = typetuple
         self._attrs = {}

--- a/normalize/empty.py
+++ b/normalize/empty.py
@@ -126,10 +126,19 @@ class EmptyVal(object):
     def __nonzero__(self):
         return False
 
+    def _typelist(self):
+        return "any" if self._typetuple is any else ",".join(
+             str(t.__name__) for t in self._typetuple
+            if isinstance(t, type)
+        )
+
+    def __repr__(self):
+        return "normalize.empty.placeholder(%s)" % self._typelist()
+
+    def __str__(self):
+        return "False(%s)" % self._typelist()
+
     def _exc(self, which, **kwargs):
         return getattr(normalize.exc, which)(
-            typenames=",".join(
-                str(t.__name__) for t in self._typetuple
-                    if isinstance(t, type)
-            ),
+            typenames=self._typelist(),
             **kwargs)

--- a/normalize/exc.py
+++ b/normalize/exc.py
@@ -75,6 +75,10 @@ class CoercionError(StringFormatException, ValueError):
     pass
 
 
+class EmptyAttributeError(StringFormatException):
+    pass
+
+
 class FieldSelectorException(StringFormatException):
     pass
 
@@ -116,6 +120,12 @@ class AttributeEmptyFault(PropertyDefinitionError, AttributeError):
     message = (
         "{prop_fullname} ('empty' function raised {exc_type_name}: "
         "{exception})"
+    )
+
+
+class BadAssignment(EmptyAttributeError, TypeError):
+    message = (
+        "Can't assign to the empty placeholder for ({typenames})"
     )
 
 
@@ -237,6 +247,24 @@ class MultipleInheritanceClash(SubclassError):
     message = (
         "Property {propname} defined by multiple base "
         "classes of {typename}"
+    )
+
+
+class NotCallable(EmptyAttributeError, TypeError):
+    message = (
+        "No types in ({typenames}) support invoking"
+    )
+
+
+class NotSubscriptable(EmptyAttributeError, TypeError):
+    message = (
+        "No types in ({typenames}) support subscripting"
+    )
+
+
+class NoSuchAttribute(EmptyAttributeError, AttributeError):
+    message = (
+        "No types in ({typenames}) have attribute '{attribute}'"
     )
 
 

--- a/normalize/record/__init__.py
+++ b/normalize/record/__init__.py
@@ -174,13 +174,6 @@ class Record(object):
         from normalize.diff import diff
         return diff(self, other, **kwargs)
 
-    def __nonzero__(self):
-        for propname, prop in type(self).properties.iteritems():
-            if not prop.extraneous:
-                if getattr(self, propname, False):
-                    return True
-        return False
-
 
 class OhPickle(object):
     """Sentinel type for Un-Pickling.  ``pickle`` does not allow a

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     packages=find_packages(),
     install_requires=('richenum>=1.0.0',),
     test_suite="run_tests",
-    version='0.7.4',
+    version='0.8.0',
     url="http://hearsaycorp.github.io/normalize",
 )

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -108,10 +108,10 @@ class TestRecords(unittest2.TestCase):
     def test_empty_type_inference(self):
 
         class OneRecord(Record):
-            foo = Property()
+            foo = Property(isa=type(2))
 
         class TwoRecord(Record):
-            bar = Property()
+            bar = Property(isa=type(None))
 
             def __call__(self):
                 return "hi"
@@ -170,9 +170,13 @@ class TestRecords(unittest2.TestCase):
             other = Property(isa=MagicList)
 
         lr = LooseRecord()
+
         self.assertFalse(lr.this0.date)
+        self.assertFalse(lr.this0.foo.real)
         with self.assertRaisesRegexp(exc.NoSuchAttribute, r"TwoRecord,datetime"):
             lr.this0.dote
+        with self.assertRaisesRegexp(exc.NoSuchAttribute, r"None"):
+            self.assertFalse(lr.this0.bar.real)
 
         self.assertFalse(lr.that0.date)
         with self.assertRaisesRegexp(exc.NotSubscriptable, r"MagicRecord"):


### PR DESCRIPTION
The approach in 0.7.0 to make Record() falsy was more anti-social than I thought.  Here's a different approach that should be less evil.

/review @tulioz @asherf @rbm 