### PR TITLE
AutoJsonRecord: access unknown keys like you declared them

### DIFF
--- a/normalize/__init__.py
+++ b/normalize/__init__.py
@@ -34,9 +34,11 @@ from normalize.property.json import JsonCollectionProperty
 from normalize.property.json import SafeJsonProperty
 from normalize.record import Record
 from normalize.record.meta import RecordMeta
+from normalize.record.json import AutoJsonRecord
 from normalize.record.json import from_json
 from normalize.record.json import JsonRecord
 from normalize.record.json import JsonRecordList
+from normalize.record.json import NCAutoJsonRecord
 from normalize.record.json import to_json
 from normalize.selector import FieldSelector
 from normalize.selector import FieldSelectorException

--- a/normalize/record/json.py
+++ b/normalize/record/json.py
@@ -596,3 +596,14 @@ class NCAutoJsonRecord(AutoJsonRecord):
     @classmethod
     def convert_json_key_out(cls, key):
         return key
+
+    @classmethod
+    def auto_upgrade_dict(cls, thing):
+        return NCAutoJsonRecord(thing)
+
+    @classmethod
+    def auto_upgrade_list(cls, thing):
+        if len(thing) and isinstance(thing[0], dict):
+            return list_of(NCAutoJsonRecord)(thing)
+        else:
+            return thing

--- a/normalize/record/json.py
+++ b/normalize/record/json.py
@@ -21,11 +21,13 @@ import collections
 from copy import deepcopy
 import inspect
 import json
+import re
 import types
 
 from normalize.coll import Collection
 from normalize.coll import DictCollection as RecordDict
 from normalize.coll import ListCollection as RecordList
+from normalize.coll import list_of
 from normalize.diff import Diff
 from normalize.diff import DiffInfo
 import normalize.exc as exc
@@ -313,7 +315,7 @@ class JsonRecord(Record):
             if extraneous or not prop.extraneous:
                 for k, v in self.unknown_json_keys.iteritems():
                     if k not in jd:
-                        jd[k] = v
+                        jd[k] = to_json(v, extraneous)
         return jd
 
     def diff_iter(self, other, **kwargs):
@@ -497,3 +499,100 @@ class JsonDiffInfo(DiffInfo, JsonRecord):
 class JsonDiff(Diff, JsonRecordList):
     """Version of 'Diff' that supports ``.json_data()``"""
     itemtype = JsonDiffInfo
+
+
+class AutoJsonRecord(JsonRecord):
+    unknown_json_keys = JsonProperty(
+        json_name=None, extraneous=False, default=lambda: {},
+    )
+
+    @classmethod
+    def auto_upgrade_dict(cls, thing):
+        return AutoJsonRecord(thing)
+
+    @classmethod
+    def auto_upgrade_list(cls, thing):
+        if len(thing) and isinstance(thing[0], dict):
+            return list_of(AutoJsonRecord)(thing)
+        else:
+            return thing
+
+    @classmethod
+    def auto_upgrade_any(cls, thing):
+        if isinstance(thing, dict):
+            return cls.auto_upgrade_dict(thing)
+        elif isinstance(thing, list):
+            return cls.auto_upgrade_list(thing)
+        else:
+            return thing
+
+    @classmethod
+    def convert_json_key_in(cls, key):
+        return re.sub(
+            r'([a-z])([A-Z])',
+            lambda m: "%s_%s" % (m.group(1), m.group(2).lower()),
+            key,
+        )
+
+    @classmethod
+    def convert_json_key_out(cls, key):
+        return re.sub(
+            r'([a-z])_([a-z])',
+            lambda m: "%s%s" % (m.group(1), m.group(2).upper()),
+            key,
+        )
+
+    @classmethod
+    def json_to_initkwargs(cls, json_data, kwargs):
+        kwargs = super(AutoJsonRecord, cls).json_to_initkwargs(
+            json_data, kwargs,
+        )
+        # upgrade any dictionaries to AutoJsonRecord, and
+        # any lists of dictionaries to list_of(AutoJsonRecord)
+        if 'unknown_json_keys' in kwargs:
+            kwargs['unknown_json_keys'] = {
+                cls.convert_json_key_in(k): cls.auto_upgrade_any(v) for
+                k, v in kwargs['unknown_json_keys'].items()
+            }
+        return kwargs
+
+    def json_data(self, extraneous=False):
+        jd = to_json(self, extraneous)
+        if hasattr(self, "unknown_json_keys"):
+            prop = type(self).properties['unknown_json_keys']
+            if extraneous or not prop.extraneous:
+                for k, v in self.unknown_json_keys.iteritems():
+                    k = cls.convert_json_key_out(k)
+                    if k not in jd:
+                        jd[k] = to_json(v, extraneous)
+        return jd
+
+    def __getattr__(self, attr):
+        if attr in type(self).properties:
+            return type(self).properties[attr].__get__(self)
+        else:
+            return self.unknown_json_keys[attr]
+
+    def __setattr__(self, attr, value):
+        if attr in type(self).properties:
+            return type(self).properties[attr].__set__(self)
+        else:
+            self.unknown_json_keys[attr]
+
+    def __delattr__(self, attr, value):
+        if attr in type(self).properties:
+            return type(self).properties[attr].__del__(self)
+        else:
+            del self.unknown_json_keys[attr]
+
+
+class NCAutoJsonRecord(AutoJsonRecord):
+    """A version of AutoJsonRecord which does not convert keys from
+    camelCase to python_form"""
+    @classmethod
+    def convert_json_key_in(cls, key):
+        return key
+
+    @classmethod
+    def convert_json_key_out(cls, key):
+        return key

--- a/tests/test_auto_records.py
+++ b/tests/test_auto_records.py
@@ -1,0 +1,63 @@
+#
+# This file is a part of the normalize python library
+#
+# normalize is free software: you can redistribute it and/or modify
+# it under the terms of the MIT License.
+#
+# normalize is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MIT License for more details.
+#
+# You should have received a copy of the MIT license along with
+# normalize.  If not, refer to the upstream repository at
+# http://github.com/hearsaycorp/normalize
+#
+
+"""test the new "auto json record" API"""
+
+from __future__ import absolute_import
+
+from datetime import datetime
+import os.path
+import unittest2
+import warnings
+
+from normalize import ListProperty
+from normalize import Property
+from normalize import Record
+from normalize import AutoJsonRecord
+import normalize.exc as exc
+
+
+class TestAutoRecords(unittest2.TestCase):
+    """Test that the new data descriptor classes work"""
+
+    def test_auto_json(self):
+
+        class MyRecord(AutoJsonRecord):
+            blah_blah = Property(json_name="blahBlah")
+
+        my_record = MyRecord(
+            {
+                "blahBlah": {"blah": "blah"},
+                "kerSploosh": "zlonk",
+                "krunch": {
+                    "crrAaack": "kapow",
+                    "eeeYow": {"whap": "aiee"},
+                },
+                "ouchEth": ["bap", "bonk"],
+                "whamEth": [
+                    {
+                        "rip": "bloop",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(my_record.blah_blah['blah'], "blah")
+        self.assertEqual(my_record.ker_sploosh, "zlonk")
+        self.assertEqual(my_record.krunch.crr_aaack, "kapow")
+        self.assertEqual(my_record.krunch.eee_yow.whap, "aiee")
+        self.assertEqual(my_record.ouch_eth[0], "bap")
+        self.assertEqual(my_record.wham_eth[0].rip, "bloop")

--- a/tests/test_auto_records.py
+++ b/tests/test_auto_records.py
@@ -27,6 +27,7 @@ from normalize import ListProperty
 from normalize import Property
 from normalize import Record
 from normalize import AutoJsonRecord
+from normalize import NCAutoJsonRecord
 import normalize.exc as exc
 
 
@@ -61,3 +62,32 @@ class TestAutoRecords(unittest2.TestCase):
         self.assertEqual(my_record.krunch.eee_yow.whap, "aiee")
         self.assertEqual(my_record.ouch_eth[0], "bap")
         self.assertEqual(my_record.wham_eth[0].rip, "bloop")
+
+    def test_nc_auto_json(self):
+
+        class MyRecord(NCAutoJsonRecord):
+            blah_blah = Property(json_name="blahBlah")
+
+        my_record = MyRecord(
+            {
+                "blahBlah": {"blah": "blah"},
+                "kerSploosh": "zlonk",
+                "krunch": {
+                    "crrAaack": "kapow",
+                    "eeeYow": {"whap": "aiee"},
+                },
+                "ouchEth": ["bap", "bonk"],
+                "whamEth": [
+                    {
+                        "rip": "bloop",
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual(my_record.blah_blah['blah'], "blah")
+        self.assertEqual(my_record.kerSploosh, "zlonk")
+        self.assertEqual(my_record.krunch.crrAaack, "kapow")
+        self.assertEqual(my_record.krunch.eeeYow.whap, "aiee")
+        self.assertEqual(my_record.ouchEth[0], "bap")
+        self.assertEqual(my_record.whamEth[0].rip, "bloop")


### PR DESCRIPTION
This new base class allows access to properties on the unknown set of JSON
keys on the input.