### PR TITLE
Modifying _GenericPickler to accomodate Python 3 names

### DIFF
--- a/normalize/coll.py
+++ b/normalize/coll.py
@@ -460,6 +460,8 @@ class _GenericPickler(object):
         self.typekey = typekey
 
     def __call__(self, values):
+        if (six.PY3) and (len(self.typekey) > 1) and (self.typekey[1].startswith('__builtin__')):
+            self.typekey = (self.typekey[0], self.typekey[1].replace('__builtin__', 'builtins'))
         return GENERIC_TYPES[self.typekey](values=values)
 
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="tests",
-    version='2.0.1',
+    version='2.0.2',
     url="http://hearsaycorp.github.io/normalize",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
/review @blalockma @scottcrooks @dizmo85 @cbueb 
This does a check on the hardcoded string in the tuple that gets passed into `__call__` and adjusts if it is Python 3. This is probably not the greatest fix ever, but I cannot figure out where this is actually getting called so it's that best I can do for now. This will fix the remaining 6 failing tests in `static_content`