### PR TITLE
Added Decimal as an instance type in to_json

### DIFF
--- a/normalize/record/json.py
+++ b/normalize/record/json.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 import inspect
 import json
 import re
+import decimal
 
 from normalize.coll import Collection
 from normalize.coll import DictCollection as RecordDict
@@ -239,7 +240,7 @@ def to_json(record, extraneous=True, prop=None):
     elif isinstance(record, (list, tuple, set, frozenset)):
         return list(_json_data(x, extraneous) for x in record)
 
-    elif isinstance(record, (basestring, int, float, type(None))):
+    elif isinstance(record, (basestring, int, float, type(None), decimal.Decimal)):
         return record
 
     else:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="tests",
-    version='2.0.2',
+    version='2.0.3',
     url="http://hearsaycorp.github.io/normalize",
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Some data I get back has `Decimal` types in it. Adding this fixes this issue, but let me know if there is a better solution:

# Before
<img width="1440" alt="Screen Shot 2020-03-06 at 10 26 52 AM" src="https://user-images.githubusercontent.com/3801897/76111466-2f817300-5f95-11ea-99ec-874aba6a51a6.png">

# After
<img width="1440" alt="Screen Shot 2020-03-06 at 10 26 38 AM" src="https://user-images.githubusercontent.com/3801897/76111472-31e3cd00-5f95-11ea-8035-4c45217b25df.png">
 

/review @abrelsfo @davidrobles @dbenzel @gdtrice @kjbhu @saraducks