### PR TITLE
Adding the Decimal type check to_json record

### DIFF
--- a/normalize/record/json.py
+++ b/normalize/record/json.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 import six
+import decimal
 
 from builtins import str
 from past.builtins import basestring
@@ -239,7 +240,7 @@ def to_json(record, extraneous=True, prop=None):
     elif isinstance(record, (list, tuple, set, frozenset)):
         return list(_json_data(x, extraneous) for x in record)
 
-    elif isinstance(record, (basestring, int, float, type(None))):
+    elif isinstance(record, (basestring, int, float, decimal.Decimal, type(None))):
         return record
 
     else:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="tests",
-    version='2.0.2',
+    version='2.0.3',
     url="http://hearsaycorp.github.io/normalize",
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -16,6 +16,7 @@
 
 
 import six
+import decimal
 from builtins import object
 from datetime import date
 from datetime import datetime
@@ -78,12 +79,29 @@ class TestTypeLibrary(unittest2.TestCase):
         self.assertIsInstance(demo.num, six.integer_types)
         demo.num = "123.0"
         self.assertIsInstance(demo.num, float)
+        demo.num = "nan"
+        self.assertIsInstance(demo.num, float)
 
         with self.assertRaises(exc.CoerceError):
             demo.num = "123.0a"
 
-        demo.num = "nan"
-        self.assertIsInstance(demo.num, float)
+        demo.num = decimal.Decimal("nan")
+        self.assertIsInstance(demo.num, decimal.Decimal)
+
+        demo.num = decimal.Decimal("123.0")
+        self.assertIsInstance(demo.num, decimal.Decimal)
+
+        demo.num = decimal.Decimal(12)
+        self.assertIsInstance(demo.num, decimal.Decimal)
+
+        with self.assertRaises(decimal.InvalidOperation):
+            demo.num = decimal.Decimal(" ")
+
+        with self.assertRaises(decimal.InvalidOperation):
+            demo.num = decimal.Decimal("abc")
+
+        with self.assertRaises(decimal.InvalidOperation):
+            demo.num = decimal.Decimal("123.0a")
 
     def test_dates_and_integer_types(self):
         class Props(Record):


### PR DESCRIPTION
Adding decimal type check to `to_json` method. An error occurred on deserializing the Decimal type hence the fix. 

https://github.com/hearsaycorp/normalize/pull/75 PR has more info. 

@abrelsfo @dbenzel @lrnwytt 